### PR TITLE
Never output decls from a different input file

### DIFF
--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/GenVisitor.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/GenVisitor.java
@@ -198,7 +198,10 @@ public class GenVisitor extends com.prismtech.lite.parser.IDLBaseVisitor <Void>
       if (oldstate.member != null)
       {
         oldstate.type = state.structMeta;
-        oldstate.decl_ctx.add ("declarations", state.struct);
+        if (generate)
+        {
+          oldstate.decl_ctx.add ("declarations", state.struct);
+        }
         oldstate.member.add ("type", state.struct.getAttribute ("name"));
         oldstate.member.add ("scope", state.struct.getAttribute ("scope"));
       }
@@ -766,7 +769,10 @@ public class GenVisitor extends com.prismtech.lite.parser.IDLBaseVisitor <Void>
 
     if (oldstate.member != null)
     {
-      oldstate.decl_ctx.add ("declarations", state.s_unionST);
+      if (generate)
+      {
+        oldstate.decl_ctx.add ("declarations", state.s_unionST);
+      }
       oldstate.member.add ("type", unionname);
       oldstate.setScope (state.member);
       oldstate.type = state.s_union;


### PR DESCRIPTION
The code used to output struct and enum definitions when (1) the definition is in the top-level input file, or (2) when the generator state indicated it was reached via a member.  This causes:
```
  // A.idl
  typedef struct A0 { long a; } A;
  // X.idl
  #include "A.idl"
  struct X { A a; };
```
to output the definition of A0 both when compiling A.idl and when compiling X.idl, leading to double definition of A0.  The problem disappears when A.idl is rewritten to:
```
  struct A0 { long a; };
  typedef A0 A;
```
which suggests the root cause may be in how it handles a typedef, rather than in the logic whether or not to generate output.  However:

* point (2) above goes against the general principle of how IDL
 compilation is expected to behave;
* addressing that appears to be sufficient to address the problem;
* this IDL compiler is about to phased out anyway

and so dealing with the apparent symptom rather than the root cause is a reasonable approach.

Signed-off-by: Erik Boasson <eb@ilities.com>