### PR TITLE
Fix sequence encoding for serializer + indicate whether unions are present

### DIFF
--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/ArrayType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/ArrayType.java
@@ -37,6 +37,16 @@ public class ArrayType extends AbstractType
     return new ArrayType (dimensions, subtype);
   }
 
+  public boolean containsUnion ()
+  {
+    Type t = subtype;
+    while (t instanceof TypedefType)
+    {
+      t = ((TypedefType)t).getRef ();
+    }
+    return t.containsUnion ();
+  }
+
   public ArrayList <String> getMetaOp (String myname, String structname)
   {
     ArrayList <String> result = new ArrayList <String> ();

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/BasicType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/BasicType.java
@@ -46,6 +46,11 @@ public class BasicType extends AbstractType
     return new BasicType (type);
   }
 
+  public boolean containsUnion ()
+  {
+    return false;
+  }
+
   public ArrayList <String> getMetaOp (String myname, String structname)
   {
     ArrayList <String> result = new ArrayList <String> (1);

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/BoundedStringType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/BoundedStringType.java
@@ -25,6 +25,11 @@ public class BoundedStringType extends AbstractType
     return size;
   }
 
+  public boolean containsUnion ()
+  {
+    return false;
+  }
+
   public ArrayList <String> getMetaOp (String myname, String structname)
   {
     ArrayList <String> result = new ArrayList <String> ();

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/EnumType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/EnumType.java
@@ -29,6 +29,11 @@ public class EnumType extends BasicType implements NamedType
     return SN.toString ("_");
   }
 
+  public boolean containsUnion ()
+  {
+    return false;
+  }
+
   public void addEnumerand (String val)
   {
     vals.add (val);

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/GenVisitor.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/GenVisitor.java
@@ -1196,6 +1196,10 @@ public class GenVisitor extends com.prismtech.lite.parser.IDLBaseVisitor <Void>
       {
         topicST.add ("flags", "DDS_TOPIC_NO_OPTIMIZE");
       }
+      if (topicmeta.containsUnion ())
+      {
+        topicST.add ("flags", "DDS_TOPIC_CONTAINS_UNION");
+      }
       topicST.add ("alignment", topicmeta.getAlignment ());
     }
 

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/SequenceType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/SequenceType.java
@@ -39,6 +39,16 @@ public class SequenceType extends AbstractType
     return new SequenceType (subtype.dup (), name, bound);
   }
 
+  public boolean containsUnion ()
+  {
+    Type t = subtype;
+    while (t instanceof TypedefType)
+    {
+      t = ((TypedefType)t).getRef ();
+    }
+    return t.containsUnion ();
+  }
+
   public ArrayList <String> getMetaOp (String myname, String structname)
   {
     ArrayList <String> result = new ArrayList <String> ();

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/SequenceType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/SequenceType.java
@@ -14,7 +14,8 @@ public class SequenceType extends AbstractType
       realsub = ((TypedefType)realsub).getRef ();
     }
     ctype = "dds_sequence_t";
-    this.bound = bound;
+    this.xmlbound = bound;
+    this.bound = 0;
   }
 
   private SequenceType (Type subtype, String ctype, long bound)
@@ -26,7 +27,8 @@ public class SequenceType extends AbstractType
       realsub = ((TypedefType)realsub).getRef ();
     }
     this.ctype = ctype;
-    this.bound = bound;
+    this.xmlbound = bound;
+    this.bound = 0;
   }
 
   public Type dup ()
@@ -63,21 +65,51 @@ public class SequenceType extends AbstractType
       offset = "0u";
     }
 
-    result.add (new String
-    (
-      "DDS_OP_ADR | DDS_OP_TYPE_SEQ | " + realsub.getSubOp () + ", " +
-      offset + ", " + Long.toString (bound)
-    ));
+    // Bounded sequences were added in an incompatible manner in this fork of the IDL
+    // compiler, the correct way would have been to add a new opcode because the encoding
+    // understood by the serializer doesn't have room for a bound
+    //
+    // Given that this compiler is end-of-life and bounded sequences currently have no
+    // effect anyway on the type or the encoding, only on the handling of samples
+    // containing oversize sequences (and no application should ever generate those), the
+    // pragmatic fix is to ignore the sequence bound.
+    if (bound == 0)
+    {
+      result.add (new String
+      (
+        "DDS_OP_ADR | DDS_OP_TYPE_SEQ | " + realsub.getSubOp () + ", " +
+        offset
+      ));
+    }
+    else
+    {
+      result.add (new String
+      (
+        "DDS_OP_ADR | DDS_OP_TYPE_BSQ | " + realsub.getSubOp () + ", " +
+        offset + ", " + Long.toString (bound)
+      ));
+    }
 
     if (!(realsub instanceof BasicType))
     {
       if (realsub instanceof BoundedStringType)
       {
-        result.add ("0, " + Long.toString (((BoundedStringType)realsub).getBound () + 1));
+        if (bound != 0)
+        {
+          result.add ("0, ");
+        }
+        result.add (Long.toString (((BoundedStringType)realsub).getBound () + 1));
       }
       else
       {
-        result.add (new String ("(" + new Integer (getMetaOpSize ()) + "u << 16u) + 5u, sizeof (" + realsub.getCType () + ")"));
+        if (bound != 0)
+        {
+          result.add (new String ("(" + new Integer (getMetaOpSize ()) + "u << 16u) + 5u, sizeof (" + realsub.getCType () + ")"));
+        }
+        else
+        {
+          result.add (new String ("sizeof (" + realsub.getCType () + "), (" + new Integer (getMetaOpSize ()) + "u << 16u) + 4u"));
+        }
         result.addAll (realsub.getMetaOp (null, null));
         result.add (new String ("DDS_OP_RTS"));
       }
@@ -109,17 +141,17 @@ public class SequenceType extends AbstractType
   {
     if (realsub instanceof BasicType)
     {
-      return 3;
+      return (bound == 0) ? 2 : 3;
     }
     else
     {
       if (realsub instanceof BoundedStringType)
       {
-        return 5;
+        return (bound == 0) ? 3 : 5;
       }
       else
       {
-        return 6 + realsub.getMetaOpSize ();
+        return ((bound == 0) ? 5 : 6) + realsub.getMetaOpSize ();
       }
     }
   }
@@ -132,9 +164,9 @@ public class SequenceType extends AbstractType
   public void getXML (StringBuffer str, ModuleContext mod)
   {
     str.append ("<Sequence");
-    if (bound != 0)
+    if (xmlbound != 0)
     {
-      str.append (" size=\\\"" + Long.toString (bound) + "\\\"");
+      str.append (" size=\\\"" + Long.toString (xmlbound) + "\\\"");
     }
     str.append (">");
     subtype.getXML (str, mod);
@@ -154,5 +186,6 @@ public class SequenceType extends AbstractType
   private final Type subtype;
   private Type realsub;
   private final String ctype;
+  private final long xmlbound;
   private final long bound;
 }

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/StructType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/StructType.java
@@ -165,6 +165,23 @@ public class StructType extends AbstractType implements NamedType
     return false;
   }
 
+  public boolean containsUnion ()
+  {
+    for (Member m : members)
+    {
+      Type mtype = m.type;
+      while (mtype instanceof TypedefType)
+      {
+        mtype = ((TypedefType)mtype).getRef ();
+      }
+      if (mtype.containsUnion ())
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public long getKeySize ()
   {
     Type mtype;

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/Type.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/Type.java
@@ -18,5 +18,6 @@ public interface Type
   public int getMetaOpSize ();
   public Alignment getAlignment ();
   public Type dup ();
+  public boolean containsUnion ();
 }
 

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/TypedefType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/TypedefType.java
@@ -16,6 +16,11 @@ public class TypedefType extends AbstractType implements NamedType
     return new TypedefType (name, ref);
   }
 
+  public boolean containsUnion ()
+  {
+    return ref.containsUnion ();
+  }
+
   public ArrayList <String> getMetaOp (String myname, String structname)
   {
     return ref.getMetaOp (myname, structname);

--- a/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/UnionType.java
+++ b/idlpp/ppresources/vlite/build/java/com/prismtech/lite/generator/UnionType.java
@@ -196,6 +196,11 @@ public class UnionType extends AbstractType implements NamedType
     less than the alignment of the members. */
   }
 
+  public boolean containsUnion ()
+  {
+    return true;
+  }
+
   public Alignment getAlignment ()
   {
     Alignment result = discriminant.getAlignment ();


### PR DESCRIPTION
This brings the output in line with that of Cyclone DDS' version of this IDL compiler and makes the encoding of sequences compatible with the serializer.

The symptom of the incorrect encoding given an unbounded sequences and bounded sequences with a bound < 2^24 is premature termination of the serialization/deserialization process. For bounded sequences with larger bounds, "stuff" will happen.